### PR TITLE
Fixed problem with ambiguous dotenv naming

### DIFF
--- a/include/dotenv.h
+++ b/include/dotenv.h
@@ -6,7 +6,7 @@
 
 namespace dotenv
 {
-    class dotenv
+    class dotenvFacade
     {
     public:
 
@@ -15,31 +15,31 @@ namespace dotenv
 
     public:
 
-        dotenv& load_dotenv(const std::string& dotenv_path = env_filename,
+        dotenvFacade& load_dotenv(const std::string& dotenv_path = env_filename,
                             const bool overwrite = false,
                             const bool interpolate = true);
 
-        const value_type operator[](const key_type& k) const;
+        value_type operator[](const key_type& k) const;
 
     public:
 
-        virtual ~dotenv() = default;
-        dotenv(const dotenv&) = delete;
-        void operator=(const dotenv&) = delete;
+        virtual ~dotenvFacade() = default;
+        dotenvFacade(const dotenvFacade&) = delete;
+        void operator=(const dotenvFacade&) = delete;
 
-        static dotenv& instance();
+        static dotenvFacade& instance();
     
     private:
 
-        dotenv() = default;
+        dotenvFacade() = default;
 
     private:
 
         static const std::string env_filename;
-        static dotenv _instance;
+        static dotenvFacade _instance;
 
     };
 
 
-    extern dotenv& env;
+    extern dotenvFacade& env;
 }

--- a/src/dotenv.cpp
+++ b/src/dotenv.cpp
@@ -11,7 +11,7 @@ using namespace std;
 using namespace dotenv;
 
 
-dotenv::dotenv& dotenv::dotenv::load_dotenv(const string& dotenv_path, const bool overwrite, const bool interpolate)
+dotenvFacade& dotenvFacade::load_dotenv(const string& dotenv_path, const bool overwrite, const bool interpolate)
 {
     ifstream env_file;
     env_file.open(dotenv_path);
@@ -27,19 +27,19 @@ dotenv::dotenv& dotenv::dotenv::load_dotenv(const string& dotenv_path, const boo
 }
 
 
-const dotenv::dotenv::value_type dotenv::dotenv::operator[](const key_type& k) const
+dotenvFacade::value_type dotenvFacade::operator[](const key_type& k) const
 {
     return getenv(k).second;
 }
 
 
-dotenv::dotenv& dotenv::dotenv::instance()
+dotenvFacade& dotenvFacade::instance()
 {
     return _instance;
 }
 
 
-const string dotenv::dotenv::env_filename = ".env";
-dotenv::dotenv dotenv::dotenv::_instance;
+const string dotenvFacade::env_filename = ".env";
+dotenvFacade dotenvFacade::_instance;
 
-dotenv::dotenv& dotenv::env = dotenv::instance();
+dotenvFacade& dotenv::env = dotenvFacade::instance();


### PR DESCRIPTION
First off, thank you for the library. I'm happy to see dotenv in cpp :-)

This is a fix for issue #21

I've renamed the `dotenv` class to `dotenvFacade` as the purpose of the class seemed to fit the [facade pattern.](https://en.wikipedia.org/wiki/Facade_pattern) Let me know if you would like the name changed to something else.
