### PR TITLE
Added the ability to build as a shared library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@
 
 # CMake specifics
 build/
+/.idea/
+/cmake-build-*/
+
+# CLion
+.clion.source.upload.marker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ set(CPP_DOTENV_SRC
 )
 if(DOTENV_SHARED_LIB)
     add_library(${CPP_DOTENV} SHARED ${CPP_DOTENV_SRC})
+    message(STATUS "Building as shared library")
 else()
     add_library(${CPP_DOTENV} ${CPP_DOTENV_SRC})
+    message(STATUS "Building as static library")
 endif()
 
 target_link_libraries(${CPP_DOTENV}
@@ -69,6 +71,7 @@ configure_file(./cpp-dotenv.pc.in ${PROJECT_BINARY_DIR}/cpp-dotenv.pc @ONLY)
 
 
 #----------------------- INSTALL --------------------------------
+include(GNUInstallDirs)
 if(DOTENV_SHARED_LIB)
     install(TARGETS ${CPP_DOTENV} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(FILES ${CMAKE_SOURCE_DIR}/include/dotenv.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,15 @@
 #----------------------- PROJECT CONFIGURATION --------------------------------
 cmake_minimum_required(VERSION 3.10)
-project(cpp-dotenv VERSION 1.0.0)
+
+project(cpp-dotenv
+        VERSION 1.0.0
+        DESCRIPTION "Library to load environment variables from .env files for C++ projects."
+        )
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(DOETENV_SHARED_LIB "Build CPP-DOTENV as a shared library" NO)
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE RELEASE)
@@ -12,6 +18,8 @@ else()
 endif()
 message(STATUS "Building CPP-DOTENV in ${CMAKE_BUILD_TYPE} mode")
 
+find_package(PkgConfig REQUIRED)
+
 #------------------- SUBDIRECTORY ADDITION ------------------------------------
 
 add_subdirectory(common)
@@ -19,13 +27,16 @@ add_subdirectory(src)
 
 #----------------------- LIBRARY CONFIGURATION --------------------------------
 
-set(CPP_DOTENV cpp_dotenv CACHE INTERNAL "")
+set(CPP_DOTENV cpp-dotenv CACHE INTERNAL "")
 set(CPP_DOTENV_SRC
     src/dotenv.cpp
     include/dotenv.h
 )
-
-add_library(${CPP_DOTENV} ${CPP_DOTENV_SRC})
+if(DOETENV_SHARED_LIB)
+    add_library(${CPP_DOTENV} SHARED ${CPP_DOTENV_SRC})
+else()
+    add_library(${CPP_DOTENV} ${CPP_DOTENV_SRC})
+endif()
 
 target_link_libraries(${CPP_DOTENV}
     ${ENVIRON_LIB}
@@ -36,6 +47,7 @@ target_include_directories(${CPP_DOTENV} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
     target_compile_options(${CPP_DOTENV} PRIVATE
         -g -Wall -O0
@@ -44,4 +56,21 @@ else()
     target_compile_options(${CPP_DOTENV} PRIVATE
         -O3
     )
+endif()
+
+#include(GNUInstallDirs)
+
+#----------------------- PKG CONFIGURATION --------------------------------
+message(STATUS "Package CPP-DOTENV for ${CMAKE_BUILD_TYPE} version ${PROJECT_VERSION}")
+set(TARGET1 ${CPP_DOTENV})
+
+# Generate pkg-config file
+configure_file(./cpp-dotenv.pc.in ${PROJECT_BINARY_DIR}/cpp-dotenv.pc @ONLY)
+
+
+#----------------------- INSTALL --------------------------------
+if(DOETENV_SHARED_LIB)
+    install(TARGETS ${CPP_DOTENV} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${CMAKE_SOURCE_DIR}/include/dotenv.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
+    install(FILES ${PROJECT_BINARY_DIR}/cpp-dotenv.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(cpp-dotenv
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(DOETENV_SHARED_LIB "Build CPP-DOTENV as a shared library" NO)
+option(DOTENV_SHARED_LIB "Build CPP-DOTENV as a shared library" NO)
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE RELEASE)
@@ -32,7 +32,7 @@ set(CPP_DOTENV_SRC
     src/dotenv.cpp
     include/dotenv.h
 )
-if(DOETENV_SHARED_LIB)
+if(DOTENV_SHARED_LIB)
     add_library(${CPP_DOTENV} SHARED ${CPP_DOTENV_SRC})
 else()
     add_library(${CPP_DOTENV} ${CPP_DOTENV_SRC})
@@ -69,7 +69,7 @@ configure_file(./cpp-dotenv.pc.in ${PROJECT_BINARY_DIR}/cpp-dotenv.pc @ONLY)
 
 
 #----------------------- INSTALL --------------------------------
-if(DOETENV_SHARED_LIB)
+if(DOTENV_SHARED_LIB)
     install(TARGETS ${CPP_DOTENV} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(FILES ${CMAKE_SOURCE_DIR}/include/dotenv.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
     install(FILES ${PROJECT_BINARY_DIR}/cpp-dotenv.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@ C++ implementation of NodeJS [dotenv](https://github.com/motdotla/dotenv) projec
 
 ## Dependencies
 
+**Shared Library Build** requires libantlr4-runtime-dev
+
+```sudo apt install libantlr4-runtime-dev```
+
+otherwise...
+
 **NONE**, for sure! :sunglasses: If it had any, it wouldn't follow the basic dotenv principles. All the needed libraries are shipped with this repository right out of the box.
+
 
 ## Build
 
 Supported build methods are:
 
 - [CMake](#cmake) (>=3.10)
+- [Shared Library](#share-library-build)
 
 ### CMake
 
@@ -54,6 +62,27 @@ target_link_libraries(YOUR_TARGET cpp_dotenv)
 ```
 
 After this, you might use the library as described in [usage](#usage); no extra scoping, no need to worry about the project's directory structure.
+
+### Share Library Build
+
+#### Build steps
+* Clone the repo
+* cd into the repo directory
+* ```mkdir build```
+* ```cd build```
+* ```cmake ../```
+* ```make install```
+
+#### Cmake 
+```
+find_package(PkgConfig REQUIRED)
+
+pkg_search_module(CPP_DOTENV QUIET cpp-dotenv)
+if(NOT CPP_DOTENV_FOUND)
+    message(ERROR "cpp-dotenv not found!")
+endif()
+target_link_libraries(YOUR_LIBRARY INTERFACE cpp-dotenv)
+```
 
 ## Usage
 

--- a/common/libs/antlr4-cpp-runtime/runtime/CMakeLists.txt
+++ b/common/libs/antlr4-cpp-runtime/runtime/CMakeLists.txt
@@ -308,7 +308,7 @@ set(ANTLR4_CPP_RUNTIME_SRC
     src/tree/xpath/XPathWildcardElement.cpp
     src/tree/xpath/XPathWildcardElement.h
 )
-if(DOETENV_SHARED_LIB)
+if(DOTENV_SHARED_LIB)
     add_library(${ANTLR4_CPP_RUNTIME} SHARED ${ANTLR4_CPP_RUNTIME_SRC})
 else()
     add_library(${ANTLR4_CPP_RUNTIME} ${ANTLR4_CPP_RUNTIME_SRC})
@@ -332,6 +332,6 @@ else()
 endif()
 
 #----------------------- INSTALL --------------------------------
-if(DOETENV_SHARED_LIB)
+if(DOTENV_SHARED_LIB)
     install(TARGETS ${ANTLR4_CPP_RUNTIME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/common/libs/antlr4-cpp-runtime/runtime/CMakeLists.txt
+++ b/common/libs/antlr4-cpp-runtime/runtime/CMakeLists.txt
@@ -308,8 +308,11 @@ set(ANTLR4_CPP_RUNTIME_SRC
     src/tree/xpath/XPathWildcardElement.cpp
     src/tree/xpath/XPathWildcardElement.h
 )
-
-add_library(${ANTLR4_CPP_RUNTIME} ${ANTLR4_CPP_RUNTIME_SRC})
+if(DOETENV_SHARED_LIB)
+    add_library(${ANTLR4_CPP_RUNTIME} SHARED ${ANTLR4_CPP_RUNTIME_SRC})
+else()
+    add_library(${ANTLR4_CPP_RUNTIME} ${ANTLR4_CPP_RUNTIME_SRC})
+endif()
 
 target_include_directories(${ANTLR4_CPP_RUNTIME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -326,4 +329,9 @@ else()
     target_compile_options(${ANTLR4_CPP_RUNTIME} PUBLIC
         -Wno-attributes
     )
+endif()
+
+#----------------------- INSTALL --------------------------------
+if(DOETENV_SHARED_LIB)
+    install(TARGETS ${ANTLR4_CPP_RUNTIME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/cpp-dotenv.pc.in
+++ b/cpp-dotenv.pc.in
@@ -1,0 +1,10 @@
+prefix=@CPACK_PACKAGE_INSTALL_DIRECTORY@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+Name: cpp-dotenv
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Requires: antlr4_cpp_runtime
+Libs: -L${libdir} -l@TARGET1@

--- a/cpp-dotenv.pc.in
+++ b/cpp-dotenv.pc.in
@@ -6,5 +6,4 @@ Name: cpp-dotenv
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
-Requires: antlr4_cpp_runtime
 Libs: -L${libdir} -l@TARGET1@


### PR DESCRIPTION
This pr modifies the cmakelists to allow for the library to be built into a shared library.
By setting the cmake option DOETENV_SHARED_LIB to yes the library is built as shared, this however seems to require that the package libantlr4-runtime-dev is installed (tested on debian).